### PR TITLE
Fix bundler CVEs, Ruby 3.x and RSpec 3 compatibility

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,4 +17,4 @@ test/version_tmp
 tmp
 
 
-vendor/ruby
+vendor/rubyvender/

--- a/.gitignore
+++ b/.gitignore
@@ -17,4 +17,5 @@ test/version_tmp
 tmp
 
 
-vendor/rubyvender/
+vendor/ruby
+vender/

--- a/.gitignore
+++ b/.gitignore
@@ -18,4 +18,3 @@ tmp
 
 
 vendor/
-vender/

--- a/.gitignore
+++ b/.gitignore
@@ -17,5 +17,5 @@ test/version_tmp
 tmp
 
 
-vendor/ruby
+vendor/
 vender/

--- a/lib/mongify/mongoid/cli/command/worker.rb
+++ b/lib/mongify/mongoid/cli/command/worker.rb
@@ -47,11 +47,11 @@ module Mongify
           #Verify tranlsation file exists
           def valid_translation? translation_file
             raise TranslationFileNotFound, "Translation file is required" unless translation_file
-            raise TranslationFileNotFound, "Unable to find Translation File #{translation_file}" unless File.exists?(translation_file)
+            raise TranslationFileNotFound, "Unable to find Translation File #{translation_file}" unless File.exist?(translation_file)
           end
 
           def prevent_overwrite! options={}
-            raise OverwritingFolder, "Output folder (#{output_folder}) already exists, for your safety we can't continue, pass -f force an overwrite" if File.exists?(output_folder) && !options[:overwrite]
+            raise OverwritingFolder, "Output folder (#{output_folder}) already exists, for your safety we can't continue, pass -f force an overwrite" if File.exist?(output_folder) && !options[:overwrite]
           end
 
           def output_success_message

--- a/lib/mongify/mongoid/generator.rb
+++ b/lib/mongify/mongoid/generator.rb
@@ -14,7 +14,7 @@ module Mongify
       # Process translation file and generate output files
       # @return [nil]
       def process
-        unless File.exists?(@translation_file)
+        unless File.exist?(@translation_file)
           raise Mongify::Mongoid::TranslationFileNotFound, "Unable to find Translation File at #{@translation_file}"
         end
 

--- a/lib/mongify/mongoid/printer.rb
+++ b/lib/mongify/mongoid/printer.rb
@@ -45,7 +45,7 @@ module Mongify
       # Renders ERB template for given model
       # @return [String] rendered template string
       def render_file model
-        ERB.new(template, nil, '-').result(model.get_binding)
+        ERB.new(template, trim_mode: '-').result(model.get_binding)
       end
 
       # Saveds text output into a file (output_directory/model_name.rb)

--- a/mongify-mongoid.gemspec
+++ b/mongify-mongoid.gemspec
@@ -25,8 +25,10 @@ Gem::Specification.new do |spec|
 
   spec.add_dependency "mongify"
 
-  spec.add_development_dependency "bundler", "~> 1.3"
+  spec.add_development_dependency "bundler", ">= 2.1"
   spec.add_development_dependency "rspec"
+  spec.add_development_dependency "rspec-its"
+  spec.add_development_dependency "rspec-collection_matchers"
   spec.add_development_dependency "rake"
   spec.add_development_dependency "guard-rspec"
   spec.add_development_dependency 'yard'

--- a/spec/lib/mongify/mongoid/cli/command/worker_spec.rb
+++ b/spec/lib/mongify/mongoid/cli/command/worker_spec.rb
@@ -4,23 +4,23 @@ describe Mongify::Mongoid::CLI::Command::Worker do
   let(:translation_file){ "spec/files/translation.rb" }
   let(:output_folder) { "spec/files/tmp" }
   subject(:worker) { Mongify::Mongoid::CLI::Command::Worker.new(translation_file) }
-  
+
   before(:each) do
-    Mongify::Mongoid::Printer.any_instance.stub(:write)
+    allow_any_instance_of(Mongify::Mongoid::Printer).to receive(:write)
   end
 
   let(:view) do
-    view = stub("View")
-    view.stub(:output)
-    view.stub(:report_success)
+    view = double("View")
+    allow(view).to receive(:output)
+    allow(view).to receive(:report_success)
     view
   end
 
   context "default output file" do
     it "should be called path + models" do
-      FileUtils.stub(:mkdir_p)
-      Mongify::Mongoid::Generator.any_instance.stub(:process)
-      worker.output_folder.should == File.join(Dir.pwd, "models")    
+      allow(FileUtils).to receive(:mkdir_p)
+      allow_any_instance_of(Mongify::Mongoid::Generator).to receive(:process)
+      worker.output_folder.should == File.join(Dir.pwd, "models")
     end
   end
 
@@ -32,14 +32,14 @@ describe Mongify::Mongoid::CLI::Command::Worker do
       lambda { Mongify::Mongoid::CLI::Command::Worker.new("missing/translation.rb").execute(view) }.should raise_error(Mongify::Mongoid::TranslationFileNotFound)
     end
   end
-  
+
   context "output folder" do
     it "raises an error if folder exist" do
       lambda { Mongify::Mongoid::CLI::Command::Worker.new(translation_file, output_folder).execute(view) }.should raise_error(Mongify::Mongoid::OverwritingFolder)
     end
     it "doesn't raise error if overwrite is true" do
-      lambda { Mongify::Mongoid::CLI::Command::Worker.new(translation_file, output_folder, :overwrite => true).execute(view) }.should_not raise_error(Mongify::Mongoid::OverwritingFolder)
+      expect { Mongify::Mongoid::CLI::Command::Worker.new(translation_file, output_folder, :overwrite => true).execute(view) }.to_not raise_error
     end
   end
-  
+
 end

--- a/spec/lib/mongify/mongoid/generator_spec.rb
+++ b/spec/lib/mongify/mongoid/generator_spec.rb
@@ -9,10 +9,10 @@ describe Mongify::Mongoid::Generator do
       subject(:generator) { Mongify::Mongoid::Generator.new(translation_file, output_dir) }
 
       it "is successful" do
-        subject.should_receive(:generate_models)
-        subject.should_receive(:process_fields)
-        subject.should_receive(:generate_embedded_relations)
-        subject.should_receive(:write_models_to_file)
+        expect(subject).to receive(:generate_models)
+        expect(subject).to receive(:process_fields)
+        expect(subject).to receive(:generate_embedded_relations)
+        expect(subject).to receive(:write_models_to_file)
 
         subject.process
       end
@@ -26,7 +26,7 @@ describe Mongify::Mongoid::Generator do
       end
 
       context "generate_models" do
-        let(:table) { stub(name: 'users', columns: [], polymorphic?: false) }
+        let(:table) { double(name: 'users', columns: [], polymorphic?: false) }
         it "should build model" do
           subject.models.should be_empty
           subject.send("build_model", table)
@@ -36,14 +36,14 @@ describe Mongify::Mongoid::Generator do
         end
       end
       context "process_fields" do
-        let(:table) { stub(name: 'users', columns: [], ignored?: false, polymorphic?: false) }
+        let(:table) { double(name: 'users', columns: [], ignored?: false, polymorphic?: false) }
         before(:each) do
-          table.stub(:columns).and_return([stub(name: "first_name", type: "string", options: {}), stub(name: "last_name", type: "string", options:{})])  
-          subject.translation.stub(:all_tables).and_return([table])
+          allow(table).to receive(:columns).and_return([double(name: "first_name", type: "string", options: {}), double(name: "last_name", type: "string", options:{})])
+          allow(subject.translation).to receive(:all_tables).and_return([table])
           subject.generate_models
         end
         it "works" do
-          subject.send(:translation).should_receive(:find).with(table.name).and_return(table)
+          expect(subject.send(:translation)).to receive(:find).with(table.name).and_return(table)
           subject.process_fields
           model = subject.find_model(table.name)
           model.should have(2).fields
@@ -51,11 +51,11 @@ describe Mongify::Mongoid::Generator do
       end
 
       context "embedded_relations" do
-        let(:table) { stub(name: 'preferences', columns: [stub(name: "Email", type:"string")], polymorphic?: false) }
+        let(:table) { double(name: 'preferences', columns: [double(name: "Email", type:"string")], polymorphic?: false) }
         let(:parent_model){ Mongify::Mongoid::Model.new(:table_name => "users", :class_name => "User")}
         before(:each) do
-          table.stub(:embed_in).and_return('users')
-          table.stub(:embedded_as_object?).and_return(true)
+          allow(table).to receive(:embed_in).and_return('users')
+          allow(table).to receive(:embedded_as_object?).and_return(true)
           subject.generate_models
           generator.models[parent_model.table_name.to_sym] = parent_model
           @model = subject.send("extract_embedded_relations", table)
@@ -74,16 +74,16 @@ describe Mongify::Mongoid::Generator do
       end
 
       context "polymorphic tables" do
-        let(:table) { stub(name: 'users', columns: [], ignored?: false, polymorphic?: false) }
-        let(:polymorphic_table){ stub(name: 'notes', columns: [], ignored?: false, polymorphic?: true, polymorphic_as: "notable") }
+        let(:table) { double(name: 'users', columns: [], ignored?: false, polymorphic?: false) }
+        let(:polymorphic_table){ double(name: 'notes', columns: [], ignored?: false, polymorphic?: true, polymorphic_as: "notable") }
         before(:each) do
-          table.stub(:columns).and_return([stub(name: "first_name", type: "string", options: {}), stub(name: "last_name", type: "string", options:{})])
+          allow(table).to receive(:columns).and_return([double(name: "first_name", type: "string", options: {}), double(name: "last_name", type: "string", options:{})])
           tables = [table, polymorphic_table]
           tables.each do |_table|
-            subject.translation.stub(:find).with(_table.name).and_return(_table)
+            allow(subject.translation).to receive(:find).with(_table.name).and_return(_table)
           end
-          
-          subject.translation.stub(:all_tables).and_return(tables)
+
+          allow(subject.translation).to receive(:all_tables).and_return(tables)
           subject.generate_models
         end
         it "should have model" do
@@ -100,13 +100,13 @@ describe Mongify::Mongoid::Generator do
       end
 
       context "generate_fields_for" do
-        let(:model) {generator.send(:build_model, stub(name: "users", polymorphic?: false))}
-        let(:parent_model) {generator.send(:build_model, stub(name: "accounts", polymorphic?: false))}
-        let(:table) {stub(name: "users", columns: [stub(name: "account_id", type: "id", options: {'references' => "accounts"})], polymorphic?: false)}
+        let(:model) {generator.send(:build_model, double(name: "users", polymorphic?: false))}
+        let(:parent_model) {generator.send(:build_model, double(name: "accounts", polymorphic?: false))}
+        let(:table) {double(name: "users", columns: [double(name: "account_id", type: "id", options: {'references' => "accounts"})], polymorphic?: false)}
         before(:each) do
           model #generate via rspec
           parent_model #generate via rspec
-          generator.translation.stub(:find).with(model.table_name).and_return(table)
+          allow(generator.translation).to receive(:find).with(model.table_name).and_return(table)
         end
         it "adds correctly" do
           generator.send(:generate_fields_for, model, table)
@@ -115,7 +115,7 @@ describe Mongify::Mongoid::Generator do
         end
       end
 
-      after(:all) do
+      after(:each) do
         FileUtils.rm  Dir["#{output_dir}/*.rb"]
       end
     end

--- a/spec/lib/mongify/mongoid/model_spec.rb
+++ b/spec/lib/mongify/mongoid/model_spec.rb
@@ -100,12 +100,12 @@ describe Mongify::Mongoid::Model do
       model.polymorphic_as = "userable"
     end
     it "should match" do
-      model.send("polymorphic_field?", "userable_id").should be_true
-      model.send("polymorphic_field?", "userable_type").should be_true
+      model.send("polymorphic_field?", "userable_id").should be_truthy
+      model.send("polymorphic_field?", "userable_type").should be_truthy
     end
     it "doesn't match" do
-      model.send("polymorphic_field?", "user_name").should be_false
-      model.send("polymorphic_field?", "userable_other").should be_false
+      model.send("polymorphic_field?", "user_name").should be_falsey
+      model.send("polymorphic_field?", "userable_other").should be_falsey
     end
 
   end

--- a/spec/lib/mongify/mongoid/printer_spec.rb
+++ b/spec/lib/mongify/mongoid/printer_spec.rb
@@ -13,26 +13,26 @@ describe Mongify::Mongoid::Printer do
 
     context "content" do
       before(:each) do
-        printer.stub(:save_file)
+        allow(printer).to receive(:save_file)
       end
       it "should be include a class" do
         output = printer.send(:render_file, model)
         output.should include("class #{model.name}")
       end
       it "should have fields" do
-        model.stub(:fields).and_return({first_name: Mongify::Mongoid::Model::Field.new("first_name", "String")})
+        allow(model).to receive(:fields).and_return({first_name: Mongify::Mongoid::Model::Field.new("first_name", "String")})
         output = printer.send(:render_file, model)
         output.should include("field :first_name, type: String")
       end
 
       it "should have relations" do
-        model.stub(:relations).and_return([Mongify::Mongoid::Model::Relation.new(:embedded_in, "posts")])
+        allow(model).to receive(:relations).and_return([Mongify::Mongoid::Model::Relation.new(:embedded_in, "posts")])
         output = printer.send(:render_file, model)
         output.should include("embedded_in :posts")
       end
 
       it "should sort relations" do
-        model.stub(:relations).and_return([
+        allow(model).to receive(:relations).and_return([
           Mongify::Mongoid::Model::Relation.new(:embeds_many, "posts"),
           Mongify::Mongoid::Model::Relation.new(:has_many, "comments"),
           Mongify::Mongoid::Model::Relation.new(:embeds_many, "addons"),
@@ -44,7 +44,7 @@ embeds_many :addons
 has_many :comments})
       end
     end
-    
+
 
     it "should create a file" do
       printer.write

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -11,4 +11,15 @@ rescue LoadError
 end
 
 require 'rspec/core'
+require 'rspec/its'
+require 'rspec/collection_matchers'
 Dir['./spec/support/**/*.rb'].map {|f| require f}
+
+RSpec.configure do |config|
+  config.mock_with :rspec do |mocks|
+    mocks.syntax = [:should, :expect]
+  end
+  config.expect_with :rspec do |expectations|
+    expectations.syntax = [:should, :expect]
+  end
+end


### PR DESCRIPTION
## Summary
- **Fix Ruby 3.x deprecations**: Replace removed `File.exists?` with `File.exist?` and update `ERB.new` to use keyword arguments
- **Resolve bundler security vulnerabilities**: Bump bundler from `~> 1.3` to `>= 2.1`, fixing CVE-2016-7954 (critical), CVE-2019-3881 (high), CVE-2020-36327 (high), CVE-2021-43809 (moderate)
- **Update test suite for RSpec 3**: Replace deprecated `stub`/`should_receive` syntax with `double`/`allow`/`expect`, add missing `rspec-its` and `rspec-collection_matchers` gems
- **Add `vender/` to `.gitignore`**

## Test plan
- [x] All 80 specs pass with `bundle exec rspec`
- [ ] Verify gem installs cleanly with `bundle install`

🤖 Generated with [Claude Code](https://claude.com/claude-code)